### PR TITLE
Fix Access denied errors

### DIFF
--- a/config/database.example.yml
+++ b/config/database.example.yml
@@ -2,7 +2,7 @@ default: &mysql
   adapter: mysql2
   pool: 5
   timeout: 5000
-  user: root
+  username: root
   password:
 
 development:


### PR DESCRIPTION
The attribute is called username, not user
Fixes the error
Access denied for user 'root'@'localhost' (using password: YES)
