### PR TITLE
Use faraday instead of open-uri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'mysql2'
 gem 'thin'
 gem 'foreman'
 gem 'faraday'
+gem 'faraday_middleware'
 
 group :test, :development do
   gem "rspec-rails", "~> 2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'mysql2'
 
 gem 'thin'
 gem 'foreman'
+gem 'faraday'
 
 group :test, :development do
   gem "rspec-rails", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,8 @@ GEM
       railties (>= 3.0.0)
     faraday (0.8.1)
       multipart-post (~> 1.1)
+    faraday_middleware (0.8.8)
+      faraday (>= 0.7.4, < 0.9)
     ffi (1.0.11)
     foreman (0.53.0)
       thor (>= 0.13.6)
@@ -181,6 +183,7 @@ PLATFORMS
 DEPENDENCIES
   factory_girl_rails
   faraday
+  faraday_middleware
   foreman
   handlebars_assets
   jasmine

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
     factory_girl_rails (3.4.0)
       factory_girl (~> 3.4.0)
       railties (>= 3.0.0)
+    faraday (0.8.1)
+      multipart-post (~> 1.1)
     ffi (1.0.11)
     foreman (0.53.0)
       thor (>= 0.13.6)
@@ -95,6 +97,7 @@ GEM
     mocha (0.11.4)
       metaclass (~> 0.0.1)
     multi_json (1.3.6)
+    multipart-post (1.1.5)
     mysql2 (0.3.11)
     polyglot (0.3.3)
     rack (1.4.1)
@@ -177,6 +180,7 @@ PLATFORMS
 
 DEPENDENCIES
   factory_girl_rails
+  faraday
   foreman
   handlebars_assets
   jasmine

--- a/app/models/graphite_url_builder.rb
+++ b/app/models/graphite_url_builder.rb
@@ -9,9 +9,9 @@ class GraphiteUrlBuilder
   end
 
   def metrics_url
-    "#{@base_url}/datapoints_targets/index.json"
+    "#{@base_url}/metrics/index.json"
   end
-  
+
   def format(timestamp)
     time = Time.at(timestamp)
     time.strftime("%H:%M_%Y%m%d")

--- a/app/models/http_proxy.rb
+++ b/app/models/http_proxy.rb
@@ -1,13 +1,19 @@
-require 'open-uri'
+require 'faraday'
+require 'faraday_middleware'
 
 module HttpProxy
   extend self
 
   def request(url)
     uri = URI.parse(url)
-    Rails.logger.debug("Requesting from #{uri} ...")
-    JSON.parse(uri.read)
-  rescue JSON::ParserError => e
+    connection = Faraday.new(url: "#{uri.scheme}://#{uri.host}:#{uri.port}") do |conn|
+      conn.request :json
+      conn.response :json, :content_type => /\bjson$/
+      conn.basic_auth(uri.user, uri.password) if uri.user or uri.password
+      conn.adapter Faraday.default_adapter
+    end
+    connection.get("#{uri.path}?#{uri.query}").body
+  rescue => e
     Rails.logger.error "Error while parsing JSON response: #{e}"
     nil
   end

--- a/app/models/sources/ci/jenkins.rb
+++ b/app/models/sources/ci/jenkins.rb
@@ -16,10 +16,9 @@ module Sources
       end
 
       def request_build_status(server_url, project)
-        request_url = "#{server_url}/job/#{project}/lastBuild/api/json"
-        uri = URI.parse(request_url)
-        Rails.logger.debug("Requesting from #{uri} ...")
-        JSON.parse(uri.read)
+        url = "#{server_url}/job/#{project}/lastBuild/api/json"
+        Rails.logger.debug("Requesting from #{url} ...")
+        ::HttpProxy.request(url)
       end
 
       def status(status)

--- a/app/models/sources/datapoints/graphite.rb
+++ b/app/models/sources/datapoints/graphite.rb
@@ -17,25 +17,25 @@ module Sources
       end
 
       def get(targets, from, to, options = {})
-        JSON.parse(request_datapoints(targets, from, to))
+        request_datapoints(targets, from, to)
       end
 
       def available_targets(options = {})
-        JSON.parse(request_available_targets)
+        request_available_targets
       end
 
       private
 
       def request_datapoints(targets, from, to)
-        uri = URI.parse(@url_builder.datapoints_url(targets, from, to))
-        Rails.logger.debug("Requesting datapoints from #{uri} ...")
-        uri.read
+        url = @url_builder.datapoints_url(targets, from, to)
+        Rails.logger.debug("Requesting datapoints from #{url} ...")
+        ::HttpProxy.request(url)
       end
 
       def request_available_targets
-        uri = URI.parse(@url_builder.metrics_url)
-        Rails.logger.debug("Requesting available targets from #{uri} ...")
-        uri.read
+        url = @url_builder.metrics_url
+        Rails.logger.debug("Requesting available targets from #{url} ...")
+        ::HttpProxy.request(url)
       end
     end
   end

--- a/spec/models/sources/datapoints/graphite_spec.rb
+++ b/spec/models/sources/datapoints/graphite_spec.rb
@@ -12,7 +12,7 @@ describe Sources::Datapoints::Graphite do
   describe "#get" do
     it "calls request_datapoints" do
       input = [{ 'target' => 'test1', 'datapoints' => [[1, 123]] }]
-      @graphite.expects(:request_datapoints).with(@targets, @from, @to).returns(input.to_json)
+      @graphite.expects(:request_datapoints).with(@targets, @from, @to).returns(input)
       result = @graphite.get(@targets, @from, @to)
       result.should eq(input)
     end


### PR DESCRIPTION
When I wanted to use TeamDashboard with a basic auth protected jenkins and graphite, it did not work because `open-uri` threw the error `userinfo not supported.  [RFC3986]`.

So I started to refactor `HttpProxy` to use [faraday](https://github.com/technoweenie/faraday). Then it threw errors when fetching the data :) So I refactored `Sources::Datapoints::Graphite` and `Sources::Ci::Jenkins` to use `HttpProxy` and not `open-uri`.

So far it seems to work :) Are you interested in some more refactoring?
