### PR TITLE
Disable loading jasmine in production

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,9 +6,11 @@ require File.expand_path('../config/application', __FILE__)
 
 TeamDashboard::Application.load_tasks
 
-require 'guard/jasmine/task'
+unless Rails.env.production?
+  require 'guard/jasmine/task'
 
-Guard::JasmineTask.new
-Guard::JasmineTask.new(:jasmine_no_server, '-s none')
+  Guard::JasmineTask.new
+  Guard::JasmineTask.new(:jasmine_no_server, '-s none')
 
-task :default => %w[spec guard:jasmine]
+  task :default => %w[spec guard:jasmine]
+end


### PR DESCRIPTION
I tried deploying to heroku and all rake tasks were failing because the Jasmine gem was not installed ( gems in the development or test groups are not installed by default on heroku). That seems pretty common in deployment so I disabled loading the Jasmine tasks in production.
