### PR TITLE
Add jenkins module to parse cc.xml

### DIFF
--- a/app/models/sources/ci/jenkins_cc.rb
+++ b/app/models/sources/ci/jenkins_cc.rb
@@ -1,0 +1,47 @@
+require 'open-uri'
+
+module Sources
+  module Ci
+    class JenkinsCc < Sources::Ci::Jenkins
+
+      # Returns ruby hash:
+      def get(options = {})
+        fields  = options.fetch(:fields)
+        project = fields.fetch(:project)
+        result  = request_build_status(fields.fetch(:server_url))
+        # older jenkins version don't return application/json as Content-Type,
+        # we need to parse it explicitly
+        result = XML::Parser.string(result).parse rescue result
+        result["Projects"]["Project"].each do |data|
+          if data['name'] == project
+            return {
+              :label             => data["name"],
+              :last_build_time   => Time.parse(data["lastBuildTime"]),
+              :last_build_status => status(data["lastBuildStatus"]),
+              :current_status    => current_status(data["activity"])
+            }
+          end
+        end
+        {}
+      end
+
+      def request_build_status(server_url)
+        url = "#{server_url}/cc.xml"
+        Rails.logger.debug("Requesting from #{url} ...")
+        ::HttpService.request(url, :ssl => {:verify => false})
+      end
+
+      def current_status(status)
+        case status
+        when /sleeping/i
+          0
+        when /building/i
+          1
+        else
+          -1
+        end
+      end
+
+    end
+  end
+end

--- a/spec/models/sources/ci/jenkins_cc_spec.rb
+++ b/spec/models/sources/ci/jenkins_cc_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+describe Sources::Ci::JenkinsCc do
+
+  before do
+    @ci = Sources::Ci::JenkinsCc.new
+    @server_url = "http://localhost"
+    @project = "test-build"
+  end
+
+  describe "#get" do
+    it "returns a hash" do
+      time = Time.now
+      input = { "Projects" => { "Project" => [{"name" => @project, "lastBuildTime" => time.iso8601, "lastBuildStatus" => "SUCCESS", "activity" => "SLEEPING" }]}}
+      @ci.expects(:request_build_status).with(@server_url).returns(input)
+      result = @ci.get(:fields => { :server_url => @server_url, :project => @project })
+      result.should == {
+        :label             => @project,
+        :last_build_time   => time.iso8601.to_s,
+        :last_build_status => 0,
+        :current_status    => 0,
+      }
+    end
+  end
+
+  describe "#request_build_status" do
+    it "calls HttpService" do
+      ::HttpService.expects(:request).with("#{@server_url}/cc.xml", :ssl => {:verify => false})
+      @ci.request_build_status(@server_url)
+    end
+  end
+
+  describe "#current_status" do
+    it "returns 0 for sleeping status" do
+      @ci.current_status('sleeping').should == 0
+    end
+
+    it "returns 1 for building status" do
+      @ci.current_status('building').should == 1
+    end
+
+    it "returns -1 otherwise" do
+      @ci.current_status(nil).should == -1
+    end
+  end
+
+end


### PR DESCRIPTION
The current jenkins implementation makes use of the JSON API which isn't available for us. So this module uses the `cc.xml` instead. 

Guess it could be merged into the current jenkins module too, what do you think?
