### PR TITLE
Fix to incorrect target names with graphite 0.9.10

### DIFF
--- a/app/controllers/api/datapoints_targets_controller.rb
+++ b/app/controllers/api/datapoints_targets_controller.rb
@@ -4,7 +4,10 @@ module Api
 
     def index
       targets = Sources.datapoints_plugin(params[:source]).available_targets(params)
-      respond_with targets.inject([]) { |result, m| result << { :name => m } }.to_json
+      targets_fixed = []
+      targets.each { |target| targets_fixed.push(target.gsub(/^\./, '')) }
+      #respond_with targets.inject([]) { |result, m| result << { :name => m } }.to_json
+      respond_with targets_fixed.inject([]) { |result, m| result << { :name => m } }.to_json
     end
 
   end


### PR DESCRIPTION
when team_dashboard is used with graphite 0.9.10, the target names are listed with initial . (dot). request fixes it. (i'm still quite a ruby n00b, but eager to learn ;])
