### PR TITLE
Add support for shell commands

### DIFF
--- a/app/models/sources/boolean/shell.rb
+++ b/app/models/sources/boolean/shell.rb
@@ -1,0 +1,16 @@
+module Sources
+   module Boolean
+      class Shell < Sources::Boolean::Base
+         def fields
+            [
+              { :name => "command", :title => "Shell Command", :mandatory => true }
+            ]
+          end
+
+          def get(options = {})
+            exec_result = %x[ #{options.fetch(:fields).fetch(:command)} ]
+            return { :value => $?.exitstatus == 0 }
+          end
+      end
+   end
+end


### PR DESCRIPTION
Added support to execute a shell command with a boolean widget and get the result back as boolean.

This shoul bring the  possibility  to monitor system service under unix systems.
