### PR TITLE
dashboard id can be set by api calls

### DIFF
--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -6,7 +6,7 @@ class Dashboard < ActiveRecord::Base
 
   after_initialize :set_defaults
 
-  attr_accessible :name, :time, :layout, :locked
+  attr_accessible :name, :time, :layout, :locked, :id
 
   protected
 


### PR DESCRIPTION
Hi,

at first, thanks for your great work!

We'd like to have a mixed setup of generated dashboards (by a script with rest calls) and custom dashboards, which is not problem so far. But when we want do recreate the generated dashboards, we need an identifier to not delete the custom dashboards. So we assigned an ID to every dashboard and use this fixed ID to assign/create the according widgets afterwards. Do you see a problem in making the dashboard ID to be accessable through the HTTP API?
