### PR TITLE
Changing targets length

### DIFF
--- a/db/migrate/20130327120046_change_targets_length_widgets.rb
+++ b/db/migrate/20130327120046_change_targets_length_widgets.rb
@@ -1,0 +1,5 @@
+class ChangeTargetsLengthWidgets < ActiveRecord::Migration
+  def change
+    change_column :widgets, :targets, :string, :limit => 5000
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130212092935) do
+ActiveRecord::Schema.define(:version => 20130327120046) do
 
   create_table "dashboards", :force => true do |t|
     t.string   "name"
@@ -27,12 +27,12 @@ ActiveRecord::Schema.define(:version => 20130212092935) do
     t.string   "kind"
     t.string   "size"
     t.string   "source"
-    t.string   "targets"
+    t.string   "targets",         :limit => 5000
     t.string   "range"
     t.text     "settings"
     t.integer  "dashboard_id"
-    t.datetime "created_at",      :null => false
-    t.datetime "updated_at",      :null => false
+    t.datetime "created_at",                      :null => false
+    t.datetime "updated_at",                      :null => false
     t.integer  "update_interval"
     t.integer  "col"
     t.integer  "row"


### PR DESCRIPTION
Hi,

if you define a widget with 3 or 4 targets surrounded by some functions (alias..), the targets entry in the database will be truncated after 255 chars (due to varchar(255)). I've set it to varchar(5000), should be enough
