### PR TITLE
Validate targets if widget kind is 'graph'

### DIFF
--- a/API.markdown
+++ b/API.markdown
@@ -85,7 +85,7 @@ Creates widget for specific dashboard
 
 Example:
 
-    curl -v -H "Content-type: application/json" -X POST -d '{ "name": "test", "source": "demo" }' http://localhost:3000/api/dashboards/1/widgets
+    curl -v -H "Content-type: application/json" -X POST -d '{ "name": "test", "source": "demo", "targets": "demo.example1;demo.example2" }' http://localhost:3000/api/dashboards/1/widgets
 
 
 ### DELETE /api/dashboards/id/widgets/id

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -5,6 +5,7 @@ class Widget < ActiveRecord::Base
 
   validates :name, :presence => true
   validates :dashboard_id, :presence => true
+  validates :targets, :presence => true, :on => :create, :if => :is_graph?
 
   after_initialize :set_defaults
 
@@ -45,4 +46,7 @@ class Widget < ActiveRecord::Base
     self.update_interval = 10 unless self.update_interval
   end
 
+  def is_graph?
+    self.kind == 'graph'
+  end
 end


### PR DESCRIPTION
The example in the API.md doesn't work

``` sh
curl -v -H "Content-type: application/json" -X POST -d '{ "name": "test", "source": "demo" }' http://localhost:3000/api/dashboards/1/widgets
```

creates an invalid graph widget because of missing targets.

I added a validation of 'targets' to the widget model in case the widget is of kind 'graph' and adapted the API.md
