### PR TITLE
round any floating number

### DIFF
--- a/app/assets/javascripts/widgets/number/directive.js
+++ b/app/assets/javascripts/widgets/number/directive.js
@@ -10,7 +10,7 @@ app.directive("number", ["NumberModel", "SuffixFormatter", function(NumberModel,
     function onSuccess(data) {
       scope.data = data;
       scope.data.label = scope.data.label || scope.widget.label;
-
+      scope.data.value = Math.round(scope.data.value);
       scope.data.stringValue = scope.widget.use_metric_suffix ? SuffixFormatter.format(scope.data.value, 1) : scope.data.value.toString();
 
       var previousData = scope.previousData;


### PR DESCRIPTION
When using datapoints from graphite, averaging the datapoints might show a number with many digits after the floating point. 
I've added a rounding function to make sure its shows an integer number.
