### PR TITLE
Add default values for optional sensu settings

### DIFF
--- a/app/models/sources/alert/sensu.rb
+++ b/app/models/sources/alert/sensu.rb
@@ -18,8 +18,8 @@ module Sources
 
       def get(options = {})
         widget                = Widget.find(options.fetch(:widget_id))
-        sensu_client_filter   = widget.settings.fetch(:sensu_clients)
-        sensu_ignored_checks  = widget.settings.fetch(:ignored_checks)
+        sensu_client_filter   = widget.settings.fetch(:sensu_clients, '')
+        sensu_ignored_checks  = widget.settings.fetch(:ignored_checks, '')
 
         #defining some global variables that will be used to store filtered data
         sensu_filtered_events = []


### PR DESCRIPTION
This is a simple bugfix for the Sensu widget.  The optional params are nil if omitted, and the validation checks empty?, so set a default empty string on the hash fetch.

You might prefer a different fix, but this is what we're currently using.  :)
