### PR TITLE
Fix incorrect percentages in numerical value widget

### DIFF
--- a/app/assets/javascripts/templates/widgets/number/show.html
+++ b/app/assets/javascripts/templates/widgets/number/show.html
@@ -3,7 +3,7 @@
 
   <div class="label-container-two-rows">
     <span class="label" title="{{data.label}}">{{data.label}}</span>
-    <div class="secondary-value-container">
+    <div class="secondary-value-container" ng-hide="data.secondaryValue == 0">
       <span ng-class="data.arrow"></span><span class="secondary-value" ng-class="data.color">{{data.secondaryValue | percentage}}</span>
     </div>
   </div>

--- a/app/assets/javascripts/widgets/number/directive.js
+++ b/app/assets/javascripts/widgets/number/directive.js
@@ -5,7 +5,10 @@ app.directive("number", ["NumberModel", "SuffixFormatter", function(NumberModel,
 
     function calculatePercentage(value, previousValue) {
       console.log("previous", previousValue, "value", value);
-      return ((value - previousValue) / value) * 100;
+      if(previousValue == 0) {
+        return 0;
+      }
+      return ((value - previousValue) / previousValue) * 100;
     }
 
     function onSuccess(data) {


### PR DESCRIPTION
This patch fixes two problems and one cosmetic issue
1. The percentage value was calculated incorrectly. The change should be a percentage of the previous value but it was being calculated as a percentage of the new value.  For example, if the value went from 50 to 100 you should see "+100%" but instead you would see "+50%".
2. If the value ever reached "0" you would see Nan and INF values due to the divide by zero
3. The change percentage is now hidden when no change occurred.  This helps highlight values that changed in a dashboard with many numerical values.
