### PR TITLE
Fix form validation so users can change range limits in the meter widget.

### DIFF
--- a/app/assets/javascripts/templates/widgets/meter/edit.html
+++ b/app/assets/javascripts/templates/widgets/meter/edit.html
@@ -51,11 +51,11 @@
   </div>
 
   <div td-field label="Minimum">
-    <input name="min" ng-model="widget.min" type="text"/>
+    <input name="min" ng-model="widget.min" type="number"/>
   </div>
 
   <div td-field label="Maximum">
-    <input name="max" ng-model="widget.max" type="text"/>
+    <input name="max" ng-model="widget.max" type="number"/>
   </div>
 
 </div>


### PR DESCRIPTION
With the input type set to 'text' as soon as you attempt to edit a limit the form validation disables the 'Save' button.  This patch uses the correct input type so the values are always numbers.  As a nice side effect you now get inc/dec buttons on the field.
