### PR TITLE
Allow hiding UI elements with a URL parameter and fix missing toolbar when exiting fullscreen.

### DIFF
--- a/app/assets/javascripts/controllers/main_ctrl.js
+++ b/app/assets/javascripts/controllers/main_ctrl.js
@@ -1,12 +1,20 @@
-app.controller("MainCtrl", ["$scope", "$rootScope", "Fullscreen", function($scope, $rootScope, Fullscreen) {
+app.controller("MainCtrl", ["$scope", "$rootScope", "$location", "Fullscreen", function($scope, $rootScope, $location, Fullscreen) {
 
-  $rootScope.fullscreen = false;
+    $rootScope.minimalui = $location.search().minimalui || false;
 
-  $scope.toggleFullscreen = function() {
-    if (!BigScreen.enabled) return;
+    BigScreen.onenter = function() {
+        $rootScope.minimalui = true;
+        $rootScope.$apply();
+    }
 
-    $rootScope.fullscreen = !$rootScope.fullscreen;
-    BigScreen.toggle();
-  };
+    BigScreen.onexit = function() {
+        $rootScope.minimalui = $location.search().minimalui || false;
+        $rootScope.$apply();
+    }
+
+    $scope.toggleFullscreen = function() {
+      if (!BigScreen.enabled) return;
+      BigScreen.toggle();
+    };
 
 }]);

--- a/app/assets/javascripts/services/fullscreen.js
+++ b/app/assets/javascripts/services/fullscreen.js
@@ -1,16 +1,7 @@
 app.factory("Fullscreen", ["$rootScope", "$timeout", function($rootScope, $timeout) {
 
   var modalElement  = $('#fullscreen-notification');
-  var navbarElement = $(".navbar");
   var timer;
-
-  function hideNavbar() {
-    navbarElement.slideUp("fast");
-  }
-
-  function showNavbar() {
-    navbarElement.slideDown("fast");
-  }
 
   function showModal() {
     modalElement.modal('show');
@@ -28,14 +19,8 @@ app.factory("Fullscreen", ["$rootScope", "$timeout", function($rootScope, $timeo
   }
 
   BigScreen.onenter = function() {
-    $rootScope.$apply(hideNavbar);
     $rootScope.$apply(showModal);
-
     timer = $timeout(hideModal, 2000);
-  };
-
-  BigScreen.onexit = function() {
-    $rootScope.$apply(showNavbar);
   };
 
   return {

--- a/app/assets/javascripts/templates/dashboards/show.html.erb
+++ b/app/assets/javascripts/templates/dashboards/show.html.erb
@@ -7,11 +7,11 @@
 
         <span class="title">{{widget.name}} <img ng-show="widget.enableSpinner" class="ajax-spinner" width="12" height="12" src="<%= asset_path('spinner2.gif') %>"></img></span>
 
-        <span class="action" ng-click="removeWidget(widget)" ng-hide="fullscreen">
+        <span class="action" ng-click="removeWidget(widget)" ng-hide="minimalui">
           <span class="ui-icon"><i class="icon icon-remove icon-white"></i></span>
         </span>
 
-        <span class="action" ng-click="editWidget(widget)" ng-hide="fullscreen">
+        <span class="action" ng-click="editWidget(widget)" ng-hide="minimalui">
           <span class="ui-icon"><i class="icon-cog icon-white"></i></span>
         </span>
 

--- a/app/assets/javascripts/templates/dashboards/toolbar.html
+++ b/app/assets/javascripts/templates/dashboards/toolbar.html
@@ -4,7 +4,7 @@
     <h2 contenteditable on-change="save()" ng-model="dashboard.name" title="Click to edit title" id='heading' style="display:inline">{{dashboard.name}}</h2>
   </div>
 
-  <div class="pull-right" ng-hide="fullscreen">
+  <div class="pull-right" ng-hide="minimalui">
 
     <div class="btn-group">
       <button ng-click="toggleFullscreen()" class="btn btn-primary">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
 
   <body ng-controller="MainCtrl" ng-cloak>
 
-    <div class="navbar navbar-static-top">
+    <div class="navbar navbar-static-top" ng-hide='minimalui'>
      <div class="navbar-inner">
        <div class="container">
          <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">


### PR DESCRIPTION
For dashboard displays we need to be able to hide headers and toolbars with a URL parameter.  This change introduces the "minimalui" query parameter that does this.  It also adds listeners for the BigScreen enter/exit events to fix the missing toolbars after exiting fullscreen.

Ultimately it might make sense to move the BigScreen code into a dedicated directive and out of MainCtrl.
